### PR TITLE
Fix Core Data transformer for receipt tags

### DIFF
--- a/Recipt/Models.swift
+++ b/Recipt/Models.swift
@@ -12,7 +12,7 @@ final class Receipt {
     var imageData: Data?
     var items: [ReceiptItem]
     var rawText: String?
-    var tags: [String]
+    @Attribute(.transformable(by: TagsValueTransformer.self)) var tags: [String]
     var notes: String?
 
     init(

--- a/Recipt/ReciptApp.swift
+++ b/Recipt/ReciptApp.swift
@@ -7,10 +7,18 @@
 
 import SwiftUI
 import SwiftData
+import Foundation
 
 @main
 struct ReciptApp: App {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+
+    init() {
+        ValueTransformer.setValueTransformer(
+            TagsValueTransformer(),
+            forName: .tagsValueTransformerName
+        )
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/Recipt/ValueTransformers.swift
+++ b/Recipt/ValueTransformers.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+@objc(TagsValueTransformer)
+final class TagsValueTransformer: NSSecureUnarchiveFromDataTransformer {
+    override static var allowedTopLevelClasses: [AnyClass] {
+        [NSArray.self, NSString.self]
+    }
+}
+
+extension NSValueTransformerName {
+    static let tagsValueTransformerName = NSValueTransformerName(
+        rawValue: String(describing: TagsValueTransformer.self)
+    )
+}


### PR DESCRIPTION
## Summary
- register a secure value transformer for serialized receipt tags
- configure the receipt model to use the secure transformer during persistence
- ensure the transformer is available when the app starts to avoid migration failures

## Testing
- not run (requires Xcode environment)


------
https://chatgpt.com/codex/tasks/task_e_68e468ab26788330bd86b3af831bcc54